### PR TITLE
Add setup script with Docker install steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Generated files
+*.log
+*.pyc
+__pycache__/
+.env
+venv/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # YardLad
 A general use yard bot, starting with a small flail mower config. 
+## Setup
+Run `./setup.sh` to install Docker and build the project container. The script prompts for each step or you can pass flags like `--install`, `--build`, and `--up`.
+
 
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+
+install_docker() {
+    echo "Installing Docker and docker-compose..."
+    sudo apt update
+    sudo apt install -y docker.io docker-compose
+    sudo usermod -aG docker "$USER"
+}
+
+build_images() {
+    echo "Building Docker images..."
+    docker-compose build
+}
+
+start_compose() {
+    echo "Starting Docker containers..."
+    docker-compose up
+}
+
+usage() {
+    echo "Usage: $0 [--install] [--build] [--up]"
+}
+
+if [ $# -eq 0 ]; then
+    read -p "Install Docker and docker-compose? [y/N] " ans
+    if [[ $ans =~ ^[Yy]$ ]]; then
+        install_docker
+    fi
+
+    read -p "Build Docker images? [y/N] " ans
+    if [[ $ans =~ ^[Yy]$ ]]; then
+        build_images
+    fi
+
+    read -p "Run docker-compose up? [y/N] " ans
+    if [[ $ans =~ ^[Yy]$ ]]; then
+        start_compose
+    fi
+else
+    for arg in "$@"; do
+        case $arg in
+            --install)
+                install_docker
+                ;;
+            --build)
+                build_images
+                ;;
+            --up)
+                start_compose
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                usage
+                exit 1
+                ;;
+        esac
+    done
+fi
+


### PR DESCRIPTION
## Summary
- add `setup.sh` with optional prompts for Docker install and compose actions
- add `.gitignore` for common generated files
- document setup steps in README

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68649b6f8d288325a1c7960ee1b842d9