### PR TITLE
Add full ROS package install to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,32 @@ FROM osrf/ros:humble-ros-base
 
 # Install common ROS 2 packages used by the project
 RUN apt-get update && apt-get install -y \
+    git \
+    build-essential \
+    python3-colcon-common-extensions \
     ros-humble-rosbridge-suite \
     ros-humble-nav2-bringup \
     ros-humble-robot-localization \
     ros-humble-foxglove-bridge \
     ros-humble-nmea-navsat-driver \
+    ros-humble-rtabmap-ros \
+    ros-humble-ros2-control \
+    ros-humble-ros2-controllers \
+    ros-humble-diff-drive-controller \
     && rm -rf /var/lib/apt/lists/*
 
 # Create workspace
 RUN mkdir -p /ros2_ws/src
 WORKDIR /ros2_ws
+
+# Fetch odrive_ros2_control package for motor control
+RUN git clone --depth 1 https://github.com/Factor-Robotics/odrive_ros2_control.git src/odrive_ros2_control
+
+# Install ROS dependencies and build the workspace
+RUN . /opt/ros/humble/setup.sh && \
+    rosdep update && \
+    rosdep install --from-paths src --ignore-src -r -y && \
+    colcon build --symlink-install
 
 # Default command keeps the container running
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ each step or you can pass flags like `--install`, `--build` and `--up`.
 - `docker-compose.yml` – Defines the containers used by the project.
 - `Dockerfile` – Builds the ROS 2 image used by `docker-compose`.
 
+The Docker image installs all ROS 2 packages listed in the Software section
+and automatically clones and builds `odrive_ros2_control` inside the
+workspace so the hardware drivers are available. The packages installed
+by apt during the image build are:
+
+```
+ros-humble-rosbridge-suite
+ros-humble-nav2-bringup
+ros-humble-robot-localization
+ros-humble-foxglove-bridge
+ros-humble-nmea-navsat-driver
+ros-humble-rtabmap-ros
+ros-humble-ros2-control
+ros-humble-ros2-controllers
+ros-humble-diff-drive-controller
+```
+
 Run `docker-compose up` (or use `./setup.sh --up`) to start the system.
 
 


### PR DESCRIPTION
## Summary
- install all ROS packages from README in the Docker image
- clone and build `odrive_ros2_control` during image build
- document the new behaviour in the README
- list the apt packages installed during the Docker build

## Testing
- `git status --short`
- `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b6789e04832583e150b321edffd5