### PR TITLE
Fix Dockerfile base image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/ros:humble-ros-base
+FROM ros:humble-ros-base
 
 # Install common ROS 2 packages used by the project
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary
- fix the Docker base image tag to use the official `ros` repo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686dab464aa48325b9aa1280f36875a9